### PR TITLE
Auprc bug

### DIFF
--- a/biopathnet/task.py
+++ b/biopathnet/task.py
@@ -139,9 +139,8 @@ class KnowledgeGraphCompletionBiomed(tasks.KnowledgeGraphCompletion, core.Config
         else:
             ranking = torch.sum(pos_pred <= pred, dim=-1) + 1 
         # get neg predictions
-        m = torch.ones_like(pred).bool()
         # mask out true pos and undesired node type
-        prob =  m.logical_and(mask).long().float()
+        prob = mask.long().float()
         # sample from neg exampels
         neg_t = functional.multinomial(prob[:,0,:], 1, replacement=True)
         neg_h = functional.multinomial(prob[:,1,:], 1, replacement=True)

--- a/biopathnet/task.py
+++ b/biopathnet/task.py
@@ -139,10 +139,9 @@ class KnowledgeGraphCompletionBiomed(tasks.KnowledgeGraphCompletion, core.Config
         else:
             ranking = torch.sum(pos_pred <= pred, dim=-1) + 1 
         # get neg predictions
-        # remove the true tail and head
-        m = torch.ones_like(pred).scatter(2, target.unsqueeze(-1), 0).bool()
-        # use mask to get rid of other true tails and heads
-        prob =  m.logical_and(~mask).long().float()
+        m = torch.ones_like(pred).bool()
+        # mask out true pos and undesired node type
+        prob =  m.logical_and(mask).long().float()
         # sample from neg exampels
         neg_t = functional.multinomial(prob[:,0,:], 1, replacement=True)
         neg_h = functional.multinomial(prob[:,1,:], 1, replacement=True)


### PR DESCRIPTION
This pull request is about fixing a bug on sampling negatives during evaluation of AUROC.

As mask will remove all positives and all nodes of undesired type, it can be directly used to sample negatives.