### PR TITLE
Add different negative sampling schemes

### DIFF
--- a/biopathnet/dataset.py
+++ b/biopathnet/dataset.py
@@ -388,6 +388,30 @@ class biomedical(data.KnowledgeGraphDataset):
 
         self.load_tsvs(txt_files, verbose=verbose)
         self.load_entity_types(path)
+        
+    def load_triplet(self, triplets, entity_vocab=None, relation_vocab=None, inv_entity_vocab=None,
+                     inv_relation_vocab=None):
+        """
+        Load the dataset from triplets.
+        The mapping between indexes and tokens is specified through either vocabularies or inverse vocabularies.
+
+        Parameters:
+            triplets (array_like): triplets of shape :math:`(n, 3)`
+            entity_vocab (dict of str, optional): maps entity indexes to tokens
+            relation_vocab (dict of str, optional): maps relation indexes to tokens
+            inv_entity_vocab (dict of str, optional): maps tokens to entity indexes
+            inv_relation_vocab (dict of str, optional): maps tokens to relation indexes
+        """
+        entity_vocab, inv_entity_vocab = self._standarize_vocab(entity_vocab, inv_entity_vocab)
+        relation_vocab, inv_relation_vocab = self._standarize_vocab(relation_vocab, inv_relation_vocab)
+
+        num_node = len(entity_vocab) if entity_vocab else None
+        num_relation = len(relation_vocab) if relation_vocab else None
+        self.graph = data.Graph(triplets, num_node=num_node, num_relation=num_relation)
+        self.entity_vocab = entity_vocab
+        self.relation_vocab = relation_vocab
+        self.inv_entity_vocab = inv_entity_vocab
+        self.inv_relation_vocab = inv_relation_vocab
 
     def load_entity_types(self, path) -> None:
         inv_type_vocab = {}

--- a/biopathnet/task.py
+++ b/biopathnet/task.py
@@ -156,6 +156,8 @@ class KnowledgeGraphCompletionBiomed(tasks.KnowledgeGraphCompletion, core.Config
             k_mat: sparse |V| * |V| adjacency matrix
         """
         logger.warning('Preprocessing for Structure Aware Negative Sampling (SANS)')
+        logger.warning('Set seed for Random Walks to 0')
+        np.random.seed(0)
 
         if n_rw == 0 or k_hop == 0:
             return None

--- a/biopathnet/task.py
+++ b/biopathnet/task.py
@@ -80,6 +80,7 @@ class KnowledgeGraphCompletionBiomed(tasks.KnowledgeGraphCompletion, core.Config
                 with self.fact_graph.graph():
                     self.fact_graph.in_degree_per_rel = self.get_in_degree_per_rel(
                         self.fact_graph.undirected(add_inverse=True))
+                    self.fact_graph.num_nodes_per_type = torch.bincount(self.fact_graph.node_type)
         else:
             # fact_graph_supervision is used to get negative samples - only remove valid and test
             self.register_buffer("fact_graph_supervision", dataset.graph.edge_mask(fact_mask))
@@ -88,7 +89,8 @@ class KnowledgeGraphCompletionBiomed(tasks.KnowledgeGraphCompletion, core.Config
             if self.neg_samp_strategy in ['degree', 'inv_degree']:
                 with self.fact_graph_supervision.graph():
                     self.fact_graph.in_degree_per_rel = self.get_in_degree_per_rel(
-                    self.fact_graph_supervision.undirected(add_inverse=True))
+                        self.fact_graph_supervision.undirected(add_inverse=True))
+                    self.fact_graph.num_nodes_per_type = torch.bincount(self.fact_graph.node_type)
             
             # fact_graph is used for message passing
             fact_mask[train_set.indices] = 0

--- a/biopathnet/util.py
+++ b/biopathnet/util.py
@@ -160,7 +160,7 @@ def get_sparse_rows(sparse_tensor, row_indices):
     size = sparse_tensor.size()
 
     # Initialize a dense tensor for the rows
-    dense_rows = torch.zeros((len(row_indices), size[1]))
+    dense_rows = torch.zeros((len(row_indices), size[1]), device=sparse_tensor.device)
 
     # Loop over each row index
     for i, row_index in enumerate(row_indices):

--- a/biopathnet/util.py
+++ b/biopathnet/util.py
@@ -152,3 +152,20 @@ def solver_load(solver, checkpoint, load_optimizer=True):
                     state[k] = v.to(solver.device)
 
     comm.synchronize()
+
+
+def get_sparse_row(sparse_tensor, row_index):
+    indices = sparse_tensor.indices()
+    values = sparse_tensor.values()
+    size = sparse_tensor.size()
+
+    # Mask to filter the desired row
+    row_mask = indices[0] == row_index
+    row_columns = indices[1][row_mask]
+    row_values = values[row_mask]
+
+    # Create a dense row (optional)
+    dense_row = torch.zeros(size[1])
+    dense_row[row_columns] = row_values
+
+    return dense_row

--- a/biopathnet/util.py
+++ b/biopathnet/util.py
@@ -154,18 +154,22 @@ def solver_load(solver, checkpoint, load_optimizer=True):
     comm.synchronize()
 
 
-def get_sparse_row(sparse_tensor, row_index):
+def get_sparse_rows(sparse_tensor, row_indices):
     indices = sparse_tensor.indices()
     values = sparse_tensor.values()
     size = sparse_tensor.size()
 
-    # Mask to filter the desired row
-    row_mask = indices[0] == row_index
-    row_columns = indices[1][row_mask]
-    row_values = values[row_mask]
+    # Initialize a dense tensor for the rows
+    dense_rows = torch.zeros((len(row_indices), size[1]))
 
-    # Create a dense row (optional)
-    dense_row = torch.zeros(size[1])
-    dense_row[row_columns] = row_values
+    # Loop over each row index
+    for i, row_index in enumerate(row_indices):
+        # Mask to filter the desired row
+        row_mask = indices[0] == row_index
+        row_columns = indices[1][row_mask]
+        row_values = values[row_mask]
 
-    return dense_row
+        # Populate the corresponding row in the dense tensor
+        dense_rows[i, row_columns] = row_values
+
+    return dense_rows

--- a/config/mock/mockdata_run.yaml
+++ b/config/mock/mockdata_run.yaml
@@ -25,6 +25,7 @@ task:
   sample_weight: no
   heterogeneous_negative: yes
   heterogeneous_evaluation: yes
+  degree_negative: yes
   full_batch_eval: no
 
 optimizer:

--- a/config/mock/mockdata_run.yaml
+++ b/config/mock/mockdata_run.yaml
@@ -25,7 +25,8 @@ task:
   sample_weight: no
   heterogeneous_negative: yes
   heterogeneous_evaluation: yes
-  #neg_samp_strategy: sans # [sans, degree, inv_degree]
+  # neg_samp_strategy: sans # [sans, degree, inv_degree]
+  # sans_rw_hops: "1000:2" # default 1000:2 # k=2 hop neighborhood approximated with 1000 random walks 
   full_batch_eval: no
 
 optimizer:

--- a/config/mock/mockdata_run.yaml
+++ b/config/mock/mockdata_run.yaml
@@ -25,7 +25,7 @@ task:
   sample_weight: no
   heterogeneous_negative: yes
   heterogeneous_evaluation: yes
-  degree_negative: yes
+  #neg_samp_strategy: sans # [sans, degree, inv_degree]
   full_batch_eval: no
 
 optimizer:

--- a/script/predict.py
+++ b/script/predict.py
@@ -23,8 +23,9 @@ def solver_load(checkpoint, load_optimizer=True):
     state = torch.load(checkpoint, map_location=solver.device)
     # some issues with loading back the fact_graph and graph
     # remove
-    state["model"].pop("fact_graph")
-    state["model"].pop("graph")
+    state["model"].pop("fact_graph", 0)
+    state["model"].pop("fact_graph_supervision", 0)
+    state["model"].pop("graph", 0)
     # load without
     solver.model.load_state_dict(state["model"], strict=False)
 

--- a/script/run.py
+++ b/script/run.py
@@ -22,8 +22,9 @@ def solver_load(checkpoint, load_optimizer=True):
     state = torch.load(checkpoint, map_location=solver.device)
     # some issues with loading back the fact_graph and graph
     # remove
-    state["model"].pop("fact_graph")
-    state["model"].pop("graph")
+    state["model"].pop("fact_graph", 0)
+    state["model"].pop("fact_graph_supervision", 0)
+    state["model"].pop("graph", 0)
     # load without
     solver.model.load_state_dict(state["model"], strict=False)
 

--- a/script/visualize.py
+++ b/script/visualize.py
@@ -21,8 +21,9 @@ def solver_load(checkpoint, load_optimizer=True):
     state = torch.load(checkpoint, map_location=solver.device)
     # some issues with loading back the fact_graph and graph
     # remove
-    state["model"].pop("fact_graph")
-    state["model"].pop("graph")
+    state["model"].pop("fact_graph", 0)
+    state["model"].pop("fact_graph_supervision", 0)
+    state["model"].pop("graph", 0)
     # load without
     solver.model.load_state_dict(state["model"], strict=False)
 

--- a/script/visualize_graph.py
+++ b/script/visualize_graph.py
@@ -34,8 +34,9 @@ def solver_load(checkpoint, load_optimizer=True):
     state = torch.load(checkpoint, map_location=solver.device)
     # some issues with loading back the fact_graph and graph
     # remove
-    state["model"].pop("fact_graph")
-    state["model"].pop("graph")
+    state["model"].pop("fact_graph", 0)
+    state["model"].pop("fact_graph_supervision", 0)
+    state["model"].pop("graph", 0)
     # load without
     solver.model.load_state_dict(state["model"], strict=False)
 


### PR DESCRIPTION
Negative sampling schemes:

- based on in degree of node given a relation type
- based on inverse in degree: num_nodes_per_type -  in_degree
- based on structure aware negative sampling

Can be applied with and without heterogeneous_negative (node aware negative)